### PR TITLE
remove node version restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "./bog.js",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": "*"
   },
   "licenses": [
     {


### PR DESCRIPTION
There is nothing in the code that would require node >= 0.10
And although engine restriction is only advisory, npm prints a scary error message every time we use `bog` with 0.8
